### PR TITLE
Update welcome message to reflect GitHub Copilot

### DIFF
--- a/WebApplication18/Pages/Index.cshtml
+++ b/WebApplication18/Pages/Index.cshtml
@@ -5,6 +5,6 @@
 }
 
 <div class="text-center">
-    <h1 class="display-4">Welcome to github training</h1>
+    <h1 class="display-4">Welcome to github copilot training</h1>
     <p>Learn about <a href="https://learn.microsoft.com/aspnet/core">building Web apps with ASP.NET Core</a>.</p>
 </div>


### PR DESCRIPTION
This pull request makes a minor update to the welcome message on the main page to reference GitHub Copilot training. No other changes are included.

- Updated the heading in `Index.cshtml` to say "Welcome to github copilot training" instead of "Welcome to github training".